### PR TITLE
added PA upload functionality

### DIFF
--- a/FTPUpload.qml
+++ b/FTPUpload.qml
@@ -1,0 +1,47 @@
+import QtQuick          2.12
+import QtQuick.Controls 2.4
+import QtQuick.Layouts  1.11
+import QtQuick.Dialogs  1.3
+
+import QGroundControl                       1.0
+import QGroundControl.Controls              1.0
+import QGroundControl.Palette               1.0
+import QGroundControl.MultiVehicleManager   1.0
+import QGroundControl.ScreenTools           1.0
+import QGroundControl.Controllers           1.0
+
+import com.FTPUpload 1.0
+
+Rectangle{
+    id : abc
+    property bool vis:false
+    Layout.fillHeight: true
+    height: parent.height
+    width: height
+    visible: vis
+
+    QGCFileDialog {
+        id:                 filePathDialog
+        title:              qsTr("Select Permission Artifact File")
+        nameFilters:        [qsTr("Permission Artifact File (*.xml *.json)"), qsTr("All Files (*)")]
+        selectExisting:     true
+        folder:             QGroundControl.settingsManager.appSettings.logSavePath
+
+        onAcceptedForLoad: {
+            controller.uploadFile(file)
+            close()
+        }
+    }
+    FTPUploadController{
+        id: controller
+    }
+
+    QGCButton {
+        height:             parent.height
+        width:              height
+        id:                 uploadButton
+        text:               qsTr("Upload\nPA")
+        onClicked:          filePathDialog.openForLoad();
+        visible:            parent.visible
+    }
+}

--- a/ftpupload.cpp
+++ b/ftpupload.cpp
@@ -1,0 +1,22 @@
+#include "ftpupload.h"
+#include <QObject>
+#include <QDebug>
+
+FTPUpload::FTPUpload(QObject *parent):QObject(parent)
+{
+
+}
+
+void FTPUpload::downloadFile(QString file)
+{
+     qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()->ftpManager()->download(QString(file), QStandardPaths::writableLocation(QStandardPaths::TempLocation));
+}
+
+void FTPUpload::uploadFile(QString path)
+{
+    QString fileName ;
+    for(auto it=path.rbegin(); it!= path.rend(); it++)
+    if(*it == '/') break;
+    else fileName.push_front(*it);
+    qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()->ftpManager()->upload(QString("APM/%1").arg(fileName), path);
+}

--- a/ftpupload.h
+++ b/ftpupload.h
@@ -1,0 +1,19 @@
+#ifndef FTPUPLOAD_H
+#define FTPUPLOAD_H
+
+#include <QObject>
+#include "MultiVehicleManager.h"
+#include "QGCApplication.h"
+#include "MockLink.h"
+#include "FTPManager.h"
+
+class FTPUpload:public QObject
+{
+    Q_OBJECT
+public:
+    explicit FTPUpload(QObject *parent = nullptr);
+    Q_INVOKABLE void downloadFile(QString file);
+    Q_INVOKABLE void uploadFile(QString path);
+};
+
+#endif // FTPUPLOAD_H

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -424,6 +424,7 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
 #
 
 HEADERS += \
+    ftpupload.h \
     src/QmlControls/QmlUnitsConversion.h \
     src/Vehicle/VehicleEscStatusFactGroup.h \
     src/api/QGCCorePlugin.h \
@@ -438,6 +439,7 @@ contains (DEFINES, QGC_ENABLE_PAIRING) {
 }
 
 SOURCES += \
+    ftpupload.cpp \
     src/Vehicle/VehicleEscStatusFactGroup.cc \
     src/api/QGCCorePlugin.cc \
     src/api/QGCOptions.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -178,7 +178,7 @@
         <file alias="QGroundControl/Controls/TerrainStatus.qml">src/PlanView/TerrainStatus.qml</file>
         <file alias="QGroundControl/Controls/TakeoffItemMapVisual.qml">src/PlanView/TakeoffItemMapVisual.qml</file>
         <file alias="QGroundControl/Controls/ToolStrip.qml">src/QmlControls/ToolStrip.qml</file>
-       	<file alias="QGroundControl/Controls/ToolStripHoverButton.qml">src/QmlControls/ToolStripHoverButton.qml</file>
+        <file alias="QGroundControl/Controls/ToolStripHoverButton.qml">src/QmlControls/ToolStripHoverButton.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemStats.qml">src/PlanView/TransectStyleComplexItemStats.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemTabBar.qml">src/PlanView/TransectStyleComplexItemTabBar.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemTerrainFollow.qml">src/PlanView/TransectStyleComplexItemTerrainFollow.qml</file>
@@ -275,6 +275,7 @@
         <file alias="VibrationPage.qml">src/AnalyzeView/VibrationPage.qml</file>
         <file alias="VirtualJoystick.qml">src/FlightDisplay/VirtualJoystick.qml</file>
         <file alias="VTOLLandingPatternEditor.qml">src/PlanView/VTOLLandingPatternEditor.qml</file>
+        <file>FTPUpload.qml</file>
     </qresource>
     <qresource prefix="/FirstRunPromptDialogs">
         <file alias="UnitsFirstRunPrompt.qml">src/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml</file>

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -108,6 +108,7 @@
 #include "ToolStripActionList.h"
 #include "QGCMAVLink.h"
 #include "VehicleLinkManager.h"
+#include "ftpupload.h"
 
 #if defined(QGC_ENABLE_PAIRING)
 #include "PairingManager.h"
@@ -520,6 +521,7 @@ void QGCApplication::_initCommon()
 
     qmlRegisterType<QGCPalette>     ("QGroundControl.Palette", 1, 0, "QGCPalette");
     qmlRegisterType<QGCMapPalette>  ("QGroundControl.Palette", 1, 0, "QGCMapPalette");
+    qmlRegisterType <FTPUpload>     ("com.FTPUpload", 1, 0, "FTPUploadController");
 
     qmlRegisterUncreatableType<Vehicle>                 (kQGCVehicle,                       1, 0, "Vehicle",                    kRefOnly);
     qmlRegisterUncreatableType<MissionManager>          (kQGCVehicle,                       1, 0, "MissionManager",             kRefOnly);

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -81,6 +81,53 @@ bool FTPManager::download(const QString& fromURI, const QString& toDir)
     return true;
 }
 
+bool FTPManager::upload(const QString& toDir, const QString& fromURI)
+{
+    qCDebug(FTPManagerLog) << "Uploading from URI:" << fromURI << "from:" << toDir;
+
+    if (!_rgStateMachine.isEmpty()) {
+        qCDebug(FTPManagerLog) << "Cannot download. Already in another operation";
+        return false;
+    }
+
+    static const StateFunctions_t rgUploadStateMachine[] = {
+        { &FTPManager::_createFileROBegin,          &FTPManager::_createFileROAckOrNak,       &FTPManager::_createFileROTimeout },
+        { &FTPManager::_writeFileBegin,             &FTPManager::_writeFileAckOrNak,          &FTPManager::_writeFileTimeout },
+      //  { &FTPManager::_fillMissingBlocksBegin,     &FTPManager::_fillMissingBlocksAckOrNak,    &FTPManager::_fillMissingBlocksTimeout },
+        { &FTPManager::_resetSessionsBegin,         &FTPManager::_resetSessionsAckOrNak,        &FTPManager::_resetSessionsTimeout },
+        { &FTPManager::_uploadCompleteNoError,    nullptr,                                    nullptr },
+    };
+    for (size_t i=0; i<sizeof(rgUploadStateMachine)/sizeof(rgUploadStateMachine[0]); i++) {
+        _rgStateMachine.append(rgUploadStateMachine[i]);
+    }
+
+    _uploadState.reset();
+    _uploadState.fullPathOnSystem.setPath(fromURI);
+
+    if (!_parseURI(toDir, _uploadState.toDir, _ftpCompId)) {
+        qCWarning(FTPManagerLog) << "_parseURI failed";
+        return false;
+    }
+
+    // We need to strip off the file name from the fully qualified path. We can't use the usual QDir
+    // routines because this path does not exist locally.
+    int lastDirSlashIndex;
+    for (lastDirSlashIndex=_uploadState.toDir.size()-1; lastDirSlashIndex>=0; lastDirSlashIndex--) {
+        if (_uploadState.toDir[lastDirSlashIndex] == '/') {
+            break;
+        }
+    }
+    lastDirSlashIndex++; // move past slash
+
+    _uploadState.fileName = _uploadState.toDir.right(_uploadState.toDir.size() - lastDirSlashIndex);
+
+    qCDebug(FTPManagerLog) << "_uploadState.toDir:_uploadState.fileName" << _uploadState.toDir << _uploadState.fileName;
+
+    _startStateMachine();
+
+    return true;
+}
+
 /// Closes out a download session by writing the file and doing cleanup.
 ///     @param errorMsg Error message, empty if no error
 void FTPManager::_downloadComplete(const QString& errorMsg)
@@ -97,11 +144,33 @@ void FTPManager::_downloadComplete(const QString& errorMsg)
         _downloadState.file.close();
         if (!errorMsg.isEmpty()) {
             _downloadState.file.remove();
+            MavlinkFTP::Request request{};
+            request.hdr.opcode  = MavlinkFTP::kCmdTerminateSession;
+            _sendRequestExpectAck(&request);
         }
     }
 
     emit downloadComplete(downloadFilePath, errorMsg);
 }
+
+
+void FTPManager::_uploadComplete(const QString& errorMsg)
+{
+    qCDebug(FTPManagerLog) << QString("_uploadComplete: errorMsg(%1)").arg(errorMsg);
+
+    QString uploadFilePath    = _uploadState.toDir;
+    QString error               = errorMsg;
+
+    _ackOrNakTimeoutTimer.stop();
+    _rgStateMachine.clear();
+    _currentStateMachineIndex = -1;
+    if (_uploadState.file.isOpen()) {
+        _uploadState.file.close();
+    }
+
+    emit uploadComplete(uploadFilePath, errorMsg);
+}
+
 
 void FTPManager::_mavlinkMessageReceived(const mavlink_message_t& message)
 {
@@ -191,10 +260,28 @@ void FTPManager::_openFileROBegin(void)
     _sendRequestExpectAck(&request);
 }
 
+void FTPManager::_createFileROBegin(void)
+{
+    MavlinkFTP::Request request{};
+    request.hdr.session = 0;
+    request.hdr.opcode  = MavlinkFTP::kCmdCreateFile;
+    request.hdr.offset  = 0;
+    request.hdr.size    = 0;
+    _fillRequestDataWithString(&request, _uploadState.toDir);
+    _sendRequestExpectAck(&request);
+}
+
+
 void FTPManager::_openFileROTimeout(void)
 {
     qCDebug(FTPManagerLog) << "_openFileROTimeout";
     _downloadComplete(tr("Download failed"));
+}
+
+void FTPManager::_createFileROTimeout(void)
+{
+    qCDebug(FTPManagerLog) << "_createFileROTimeout";
+    _uploadComplete(tr("Upload failed"));
 }
 
 void FTPManager::_openFileROAckOrNak(const MavlinkFTP::Request* ackOrNak)
@@ -237,6 +324,44 @@ void FTPManager::_openFileROAckOrNak(const MavlinkFTP::Request* ackOrNak)
     }
 }
 
+void FTPManager::_createFileROAckOrNak(const MavlinkFTP::Request* ackOrNak)
+{
+    MavlinkFTP::OpCode_t requestOpCode = static_cast<MavlinkFTP::OpCode_t>(ackOrNak->hdr.req_opcode);
+    if (requestOpCode != MavlinkFTP::kCmdCreateFile) {
+        qCDebug(FTPManagerLog) << "_createFileROAckOrNak: Ack disregarding ack for incorrect requestOpCode" << MavlinkFTP::opCodeToString(requestOpCode);
+        return;
+    }
+    if (ackOrNak->hdr.seqNumber != _expectedIncomingSeqNumber) {
+        qCDebug(FTPManagerLog) << "_createFileROAckOrNak: Ack disregarding ack for incorrect sequence actual:expected" << ackOrNak->hdr.seqNumber << _expectedIncomingSeqNumber;
+        return;
+    }
+
+    _ackOrNakTimeoutTimer.stop();
+
+    if (ackOrNak->hdr.opcode == MavlinkFTP::kRspAck) {
+        qCDebug(FTPManagerLog) << "_createFileROAckOrNak: Ack  - sessionId:createFileLength" << ackOrNak->hdr.session << ackOrNak->openFileLength;
+
+        if (ackOrNak->hdr.size != 0) {
+            qCDebug(FTPManagerLog) << "_openFileROAckOrNak: Ack ack->hdr.size != sizeof(uint32_t)" << ackOrNak->hdr.size << sizeof(uint32_t);
+            _uploadComplete(tr("Create File failed"));
+            return;
+        }
+
+        _uploadState.sessionId        = ackOrNak->hdr.session;
+        _uploadState.expectedOffset   = 0;
+        _uploadState.file.setFileName(_uploadState.fullPathOnSystem.path());
+        if (_uploadState.file.open(QFile::ReadOnly)) {
+            _advanceStateMachine();
+        } else {
+            qCDebug(FTPManagerLog) << "_createFileROAckOrNak: Ack _uploadState.file open failed" << _uploadState.file.errorString();
+            _uploadComplete(tr("openFile on system failed"));
+        }
+    } else if (ackOrNak->hdr.opcode == MavlinkFTP::kRspNak) {
+        qCDebug(FTPManagerLog) << "_handlOpenFileROAck: Nak -" << _errorMsgFromNak(ackOrNak);
+        _uploadComplete(tr("createFile failed"));
+    }
+}
+
 void FTPManager::_burstReadFileWorker(bool firstRequest)
 {
     qCDebug(FTPManagerLog) << "_burstReadFileWorker: starting burst at offset:firstRequest:retryCount" << _downloadState.expectedOffset << firstRequest << _downloadState.retryCount;
@@ -257,9 +382,52 @@ void FTPManager::_burstReadFileWorker(bool firstRequest)
     _sendRequestExpectAck(&request);
 }
 
+void FTPManager::_burstWriteFileWorker(bool firstRequest)
+{
+    qCDebug(FTPManagerLog) << "_burstWriteFileWorker: starting burst at offset:firstRequest:retryCount" << _uploadState.expectedOffset << firstRequest << _uploadState.retryCount;
+
+       MavlinkFTP::Request request{};
+       request.hdr.session = _uploadState.sessionId;
+       request.hdr.opcode  = MavlinkFTP::kCmdWriteFile;
+       request.hdr.offset  = _uploadState.expectedOffset;
+
+       if (firstRequest) {
+           _uploadState.retryCount = 0;
+       } else {
+           // Must used same sequence number as previous request
+           _expectedIncomingSeqNumber -= 2;
+       }
+       _uploadState.file.seek(request.hdr.offset);
+       if (_uploadState.file.atEnd()){
+           request.hdr.opcode = MavlinkFTP::kCmdTerminateSession;
+           _sendRequestExpectAck(&request);
+           _uploadState.file.close();
+           _advanceStateMachine();
+       }
+       if (_uploadState.file.size()-request.hdr.offset< MAVLINK_MSG_FILE_TRANSFER_PROTOCOL_FIELD_PAYLOAD_LEN - 11){
+
+           QString content =_uploadState.file.read(_uploadState.file.size()-request.hdr.offset);
+           _fillRequestDataWithString(&request, content);
+       }
+       else{
+       QString content =_uploadState.file.read(MAVLINK_MSG_FILE_TRANSFER_PROTOCOL_FIELD_PAYLOAD_LEN - 11);
+       _fillRequestDataWithString(&request, content);
+       }
+       _uploadState.bytesWritten += request.hdr.size;
+       _uploadState.expectedOffset = request.hdr.offset + request.hdr.size;
+       _sendRequestExpectAck(&request);
+}
+
+
+
 void FTPManager::_burstReadFileBegin(void)
 {
     _burstReadFileWorker(true /* firstRequestr */);
+}
+
+void FTPManager::_writeFileBegin(void)
+{
+    _burstWriteFileWorker(true /* firstRequestr */);
 }
 
 void FTPManager::_burstReadFileAckOrNak(const MavlinkFTP::Request* ackOrNak)
@@ -323,6 +491,9 @@ void FTPManager::_burstReadFileAckOrNak(const MavlinkFTP::Request* ackOrNak)
             _expectedIncomingSeqNumber = ackOrNak->hdr.seqNumber + 1;
             _ackOrNakTimeoutTimer.start();
         }
+
+
+
     } else if (ackOrNak->hdr.opcode == MavlinkFTP::kRspNak) {
         if (ackOrNak->hdr.seqNumber != _expectedIncomingSeqNumber) {
             qCDebug(FTPManagerLog) << "_burstReadFileAckOrNak: Disregarding Nak due to incorrect sequence actual:expected" << ackOrNak->hdr.seqNumber << _expectedIncomingSeqNumber;
@@ -342,6 +513,50 @@ void FTPManager::_burstReadFileAckOrNak(const MavlinkFTP::Request* ackOrNak)
     }
 }
 
+
+void FTPManager::_writeFileAckOrNak(const MavlinkFTP::Request* ackOrNak)
+{
+    MavlinkFTP::OpCode_t requestOpCode = static_cast<MavlinkFTP::OpCode_t>(ackOrNak->hdr.req_opcode);
+
+        if (requestOpCode != MavlinkFTP::kCmdWriteFile) {
+            qCDebug(FTPManagerLog) << "_WriteFileAckOrNak: Disregarding due to incorrect requestOpCode" << MavlinkFTP::opCodeToString(requestOpCode);
+            return;
+        }
+        if (ackOrNak->hdr.session != _uploadState.sessionId) {
+            qCDebug(FTPManagerLog) << "_WriteFileAckOrNak: Disregarding due to incorrect session id actual:expected" << ackOrNak->hdr.session << _uploadState.sessionId;
+            return;
+        }
+
+        _ackOrNakTimeoutTimer.stop();
+
+        if (ackOrNak->hdr.opcode == MavlinkFTP::kRspAck) {
+            if (ackOrNak->hdr.seqNumber < _expectedIncomingSeqNumber) {
+                qCDebug(FTPManagerLog) << "_WriteFileAckOrNak: Disregarding Ack due to incorrect sequence actual:expected" << ackOrNak->hdr.seqNumber << _expectedIncomingSeqNumber;
+                return;
+            }
+
+            qCDebug(FTPManagerLog) << QString("_burstReadFileAckOrNak: Ack offset(%1) size(%2) burstComplete(%3)").arg(ackOrNak->hdr.offset).arg(ackOrNak->hdr.size).arg(ackOrNak->hdr.burstComplete);
+
+            _burstWriteFileWorker(true /* firstRequest */);
+         }
+        else if (ackOrNak->hdr.opcode == MavlinkFTP::kRspNak)
+            {
+             if (ackOrNak->hdr.seqNumber != _expectedIncomingSeqNumber) {
+                 qCDebug(FTPManagerLog) << "_WriteFileAckOrNak: Disregarding Nak due to incorrect sequence actual:expected" << ackOrNak->hdr.seqNumber << _expectedIncomingSeqNumber;
+                 return;
+             }
+
+             MavlinkFTP::ErrorCode_t errorCode = static_cast<MavlinkFTP::ErrorCode_t>(ackOrNak->data[0]);
+             if (errorCode == MavlinkFTP::kErrEOF) {
+                 // Burst sequence has gone through the whole file
+                 qCDebug(FTPManagerLog) << "_burstReadFileAckOrNak EOF";
+                 _advanceStateMachine();
+             }
+            else{
+            qCDebug(FTPManagerLog) << "_writeFileAckOrNak: Nak -" << _errorMsgFromNak(ackOrNak);
+            _uploadComplete(tr("Upload failed"));}
+           }
+    }
 void FTPManager::_burstReadFileTimeout(void)
 {
     if (++_downloadState.retryCount > _maxRetry) {
@@ -351,6 +566,18 @@ void FTPManager::_burstReadFileTimeout(void)
         // Try again
         qCDebug(FTPManagerLog) << QString("_burstReadFileTimeout: retrying - retryCount(%1) offset(%2)").arg(_downloadState.retryCount).arg(_downloadState.expectedOffset);
         _burstReadFileWorker(false /* firstReqeust */);
+    }
+}
+
+void FTPManager::_writeFileTimeout(void)
+{
+    if (++_uploadState.retryCount > _maxRetry) {
+        qCDebug(FTPManagerLog) << QString("_burstWriteFileTimeout retries exceeded");
+        _uploadComplete(tr("Upload failed"));
+    } else {
+        // Try again
+        qCDebug(FTPManagerLog) << QString("_writeFileTimeout: retrying - retryCount(%1) offset(%2)").arg(_uploadState.retryCount).arg(_uploadState.expectedOffset);
+        _burstWriteFileWorker(false /* firstReqeust */);
     }
 }
 
@@ -451,6 +678,8 @@ void FTPManager::_fillMissingBlocksAckOrNak(const MavlinkFTP::Request* ackOrNak)
 
         // Move on to fill in possible next hole
         _fillMissingBlocksWorker(true /* firstReqeust */);
+
+
     } else if (ackOrNak->hdr.opcode == MavlinkFTP::kRspNak) {
         MavlinkFTP::ErrorCode_t errorCode = static_cast<MavlinkFTP::ErrorCode_t>(ackOrNak->data[0]);
 

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -18,6 +18,7 @@
 #include "QGCCorePlugin.h"
 #include "QGCOptions.h"
 #include "LinkManager.h"
+#include "FTPManager.h"
 
 #if defined (__ios__) || defined(__android__)
 #include "MobileScreenMgr.h"

--- a/src/ui/toolbar/MainToolBar.qml
+++ b/src/ui/toolbar/MainToolBar.qml
@@ -18,6 +18,8 @@ import QGroundControl.Palette               1.0
 import QGroundControl.MultiVehicleManager   1.0
 import QGroundControl.ScreenTools           1.0
 import QGroundControl.Controllers           1.0
+import com.FTPUpload 1.0
+import "qrc:/qml"
 
 Rectangle {
     id:     _root
@@ -83,6 +85,18 @@ Rectangle {
             onClicked:          _activeVehicle.closeVehicle()
             visible:            _activeVehicle && _communicationLost && currentToolbar === flyViewToolbar
         }
+
+        FTPUploadController{
+            id: controller
+        }
+
+        FTPUpload{
+            id:abc
+            vis:  _activeVehicle
+
+        }
+
+
     }
 
     QGCFlickable {


### PR DESCRIPTION
This Pull Request provides the following capabilities.

1. Send a file to the drone SD Card via MAVFTP  (can be used _for Permission Artifact File (PA)_,  _LogFetching_)

2. Get a file from the drone SD Card via MAVFTP (_Can be used for Fetching logs and Done Key_)

3. At the UI side, an Upload PA button is provided which opens a file selector manually to browse and upload your PA in the APM/ directory

![image](https://user-images.githubusercontent.com/43859232/134446420-64eb8108-25e3-42df-87e4-da9fa85b8fbd.png)

